### PR TITLE
promise support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ module.exports = (dirname, manifestExtras) => {
 
         if (typeof next === 'function') {
             return Haute(dirname, manifest)(server, options, next);
-        } else if (typeof options === 'function') {
+        }
+        else if (typeof options === 'function') {
             next = options;
             return Haute(dirname, manifest)(server, next);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,17 +15,13 @@ module.exports = (dirname, manifestExtras) => {
 
     return (server, options, next) => {
 
-        if (typeof options === 'function' ||
-            typeof next === 'function') {
-
-            // callback style
-            if (typeof next === 'function') {
-                return Haute(dirname, manifest)(server, options, next);
-            }
-
+        if (typeof next === 'function') {
+            return Haute(dirname, manifest)(server, options, next);
+        } else if (typeof options === 'function') {
             next = options;
             return Haute(dirname, manifest)(server, next);
         }
+
 
         return new Promise((resolve, reject) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,5 +13,38 @@ module.exports = (dirname, manifestExtras) => {
 
     const manifest = Manifest.concat(manifestExtras || []);
 
-    return Haute(dirname, manifest);
+    return (server, options, next) => {
+
+        if (typeof options === 'function' ||
+            typeof next === 'function') {
+
+            // callback style
+            if (typeof next === 'function') {
+                return Haute(dirname, manifest)(server, options, next);
+            }
+
+            next = options;
+            return Haute(dirname, manifest)(server, next);
+        }
+
+        return new Promise((resolve, reject) => {
+
+            const cb = function (err) {
+
+                if (err) {
+                    reject(err);
+                }
+                else {
+                    resolve();
+                }
+            };
+
+            if (typeof options !== 'undefined') {
+                Haute(dirname, manifest)(server, options, cb);
+            }
+            else {
+                Haute(dirname, manifest)(server, cb);
+            }
+        });
+    };
 };

--- a/test/closet/bad-plugin/plugins.js
+++ b/test/closet/bad-plugin/plugins.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const internals = {};
+
+internals.plugin = (srv, options, next) => {
+
+    next(new Error('Ya blew it!'));
+};
+
+internals.plugin.attributes = { name: 'err-plugin' };
+
+module.exports = [{ plugins: internals.plugin }];

--- a/test/index.js
+++ b/test/index.js
@@ -475,47 +475,47 @@ describe('HauteCouture', () => {
 
     it('allows options to be optional', (done) => {
 
-        const opCbSrv = new Hapi.Server();
-        opCbSrv.connection();
+        const server = new Hapi.Server();
+        server.connection();
 
-        const opCbPlugin = (server, options, next) => {
+        const plugin = (srv, options, next) => {
 
-            HauteCouture(`${__dirname}/closet/specific`)(server, (err) => {
+            HauteCouture(`${__dirname}/closet/specific`)(srv, (err) => {
 
                 if (err) {
                     return next(err);
                 }
 
-                expect(opCbSrv.registrations['specific-sub-plugin']).to.exist();
+                expect(srv.registrations['specific-sub-plugin']).to.exist();
 
                 next();
             });
         };
 
-        opCbPlugin.attributes = { name: 'no-options-plugin' };
+        plugin.attributes = { name: 'no-options-plugin' };
 
-        opCbSrv.register(opCbPlugin, (err) => {
+        server.register(plugin, (err) => {
 
             if (err) {
                 return done(err);
             }
 
-            expect(opCbSrv.registrations['no-options-plugin']).to.exist();
+            expect(server.registrations['no-options-plugin']).to.exist();
             done();
         });
     });
 
     it('supports promises.', (done) => {
 
-        const prSrv = new Hapi.Server();
-        prSrv.connection();
+        const server = new Hapi.Server();
+        server.connection();
 
-        const prPlugin = (server, options, next) => {
+        const plugin = (srv, options, next) => {
 
-            HauteCouture(`${__dirname}/closet/specific`)(server, options)
+            HauteCouture(`${__dirname}/closet/specific`)(srv, options)
             .then(() => {
 
-                expect(prSrv.registrations['specific-sub-plugin']).to.exist();
+                expect(srv.registrations['specific-sub-plugin']).to.exist();
                 next();
             })
             .catch((err) => {
@@ -524,30 +524,30 @@ describe('HauteCouture', () => {
             });
         };
 
-        prPlugin.attributes = { name: 'promise-plugin' };
+        plugin.attributes = { name: 'promise-plugin' };
 
-        prSrv.register(prPlugin, (err) => {
+        server.register(plugin, (err) => {
 
             if (err) {
                 return done(err);
             }
 
-            expect(prSrv.registrations['promise-plugin']).to.exist();
+            expect(server.registrations['promise-plugin']).to.exist();
             done();
         });
     });
 
     it('allows options, next to be optional.', (done) => {
 
-        const opSrv = new Hapi.Server();
-        opSrv.connection();
+        const server = new Hapi.Server();
+        server.connection();
 
-        const opPlugin = (server, options, next) => {
+        const plugin = (srv, options, next) => {
 
-            HauteCouture(`${__dirname}/closet/specific`)(server)
+            HauteCouture(`${__dirname}/closet/specific`)(srv)
             .then(() => {
 
-                expect(opSrv.registrations['specific-sub-plugin']).to.exist();
+                expect(srv.registrations['specific-sub-plugin']).to.exist();
                 next();
             })
             .catch((err) => {
@@ -556,25 +556,25 @@ describe('HauteCouture', () => {
             });
         };
 
-        opPlugin.attributes = { name: 'no-options-no-callback-plugin' };
+        plugin.attributes = { name: 'no-options-no-callback-plugin' };
 
-        opSrv.register(opPlugin, (err) => {
+        server.register(plugin, (err) => {
 
             if (err) {
                 return done(err);
             }
 
-            expect(opSrv.registrations['no-options-no-callback-plugin']).to.exist();
+            expect(server.registrations['no-options-no-callback-plugin']).to.exist();
             done();
         });
     });
 
     it('promise returns error in catch.', (done) => {
 
-        const errSrv = new Hapi.Server();
-        errSrv.connection();
+        const server = new Hapi.Server();
+        server.connection();
 
-        HauteCouture(`${__dirname}/closet/bad-plugin`)(errSrv)
+        HauteCouture(`${__dirname}/closet/bad-plugin`)(server)
         .then(() => {
 
             return done(new Error('Shouldn\'t make it here!'));

--- a/test/index.js
+++ b/test/index.js
@@ -216,7 +216,6 @@ describe('HauteCouture', () => {
                 done();
             });
         });
-
     });
 
     it('registers extensions in extensions/.', (done) => {
@@ -474,4 +473,120 @@ describe('HauteCouture', () => {
         });
     });
 
+    it('allows options to be used as a callback', (done, onCleanup) => {
+
+        onCleanup((next) => {
+
+            reset();
+            return next();
+        });
+
+        const opCbSrv = new Hapi.Server();
+        opCbSrv.connection();
+
+        const opCbPlugin = (server, options, next) => {
+
+            HauteCouture()(server, (err) => {
+
+                if (err) {
+                    return next(err);
+                }
+                next();
+            });
+        };
+
+        opCbPlugin.attributes = { name: 'no-options-plugin' };
+
+        opCbSrv.register(opCbPlugin, (err) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            expect(opCbSrv.registrations['no-options-plugin']).to.exist();
+            done();
+        });
+    });
+
+    it('supports promises.', (done, onCleanup) => {
+
+        const prSrv = new Hapi.Server();
+        prSrv.connection();
+
+        const prPlugin = (server, options, next) => {
+
+            HauteCouture()(server, options)
+            .then(() => {
+
+                next();
+            })
+            .catch((err) => {
+
+                next(err);
+            });
+        };
+
+        prPlugin.attributes = { name: 'promise-plugin' };
+
+        prSrv.register(prPlugin, (err) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            expect(bigServer.registrations.vision).to.exist();
+            done();
+        });
+    });
+
+    it('allows options, next to be optional.', (done, onCleanup) => {
+
+        const opSrv = new Hapi.Server();
+        opSrv.connection();
+
+        const opPlugin = (server, options, next) => {
+
+            HauteCouture()(server)
+            .then(() => {
+
+                next();
+            })
+            .catch((err) => {
+
+                next(err);
+            });
+        };
+
+        opPlugin.attributes = { name: 'no-options-no-callback-plugin' };
+
+        opSrv.register(opPlugin, (err) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            expect(opSrv.registrations['no-options-no-callback-plugin']).to.exist();
+            done();
+        });
+    });
+
+    it('promise returns error in catch.', (done, onCleanup) => {
+
+        onCleanup((next) => {
+
+            reset();
+            return next();
+        });
+
+        const errSrv = new Hapi.Server();
+        errSrv.connection();
+
+        HauteCouture(`${__dirname}/closet/bad-plugin`)(errSrv)
+        .then(Hoek.ignore)
+        .catch((err) => {
+
+            expect(err).to.exist();
+            done();
+        });
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -473,18 +473,21 @@ describe('HauteCouture', () => {
         });
     });
 
-    it('allows options to be used as a callback', (done) => {
+    it('allows options to be optional', (done) => {
 
         const opCbSrv = new Hapi.Server();
         opCbSrv.connection();
 
         const opCbPlugin = (server, options, next) => {
 
-            HauteCouture()(server, (err) => {
+            HauteCouture(`${__dirname}/closet/specific`)(server, (err) => {
 
                 if (err) {
                     return next(err);
                 }
+
+                expect(opCbSrv.registrations['specific-sub-plugin']).to.exist();
+
                 next();
             });
         };
@@ -509,9 +512,10 @@ describe('HauteCouture', () => {
 
         const prPlugin = (server, options, next) => {
 
-            HauteCouture()(server, options)
+            HauteCouture(`${__dirname}/closet/specific`)(server, options)
             .then(() => {
 
+                expect(prSrv.registrations['specific-sub-plugin']).to.exist();
                 next();
             })
             .catch((err) => {
@@ -528,7 +532,7 @@ describe('HauteCouture', () => {
                 return done(err);
             }
 
-            expect(bigServer.registrations.vision).to.exist();
+            expect(prSrv.registrations['promise-plugin']).to.exist();
             done();
         });
     });
@@ -540,9 +544,10 @@ describe('HauteCouture', () => {
 
         const opPlugin = (server, options, next) => {
 
-            HauteCouture()(server)
+            HauteCouture(`${__dirname}/closet/specific`)(server)
             .then(() => {
 
+                expect(opSrv.registrations['specific-sub-plugin']).to.exist();
                 next();
             })
             .catch((err) => {
@@ -570,6 +575,10 @@ describe('HauteCouture', () => {
         errSrv.connection();
 
         HauteCouture(`${__dirname}/closet/bad-plugin`)(errSrv)
+        .then(() => {
+
+            return done(new Error('Shouldn\'t make it here!'));
+        })
         .catch((err) => {
 
             expect(err.message).to.equal('Ya blew it!');

--- a/test/index.js
+++ b/test/index.js
@@ -473,13 +473,7 @@ describe('HauteCouture', () => {
         });
     });
 
-    it('allows options to be used as a callback', (done, onCleanup) => {
-
-        onCleanup((next) => {
-
-            reset();
-            return next();
-        });
+    it('allows options to be used as a callback', (done) => {
 
         const opCbSrv = new Hapi.Server();
         opCbSrv.connection();
@@ -508,7 +502,7 @@ describe('HauteCouture', () => {
         });
     });
 
-    it('supports promises.', (done, onCleanup) => {
+    it('supports promises.', (done) => {
 
         const prSrv = new Hapi.Server();
         prSrv.connection();
@@ -539,7 +533,7 @@ describe('HauteCouture', () => {
         });
     });
 
-    it('allows options, next to be optional.', (done, onCleanup) => {
+    it('allows options, next to be optional.', (done) => {
 
         const opSrv = new Hapi.Server();
         opSrv.connection();
@@ -570,22 +564,15 @@ describe('HauteCouture', () => {
         });
     });
 
-    it('promise returns error in catch.', (done, onCleanup) => {
-
-        onCleanup((next) => {
-
-            reset();
-            return next();
-        });
+    it('promise returns error in catch.', (done) => {
 
         const errSrv = new Hapi.Server();
         errSrv.connection();
 
         HauteCouture(`${__dirname}/closet/bad-plugin`)(errSrv)
-        .then(Hoek.ignore)
         .catch((err) => {
 
-            expect(err).to.exist();
+            expect(err.message).to.equal('Ya blew it!');
             done();
         });
     });


### PR DESCRIPTION
@devinivy Should tests all be duplicated for the promise version? I was fiddling with how I might do that by abstracting out the function passed to "describe", but lab didn't like that.

Or are we replacing callback functionality?